### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ This is a sample application of using the [ArcGIS API for JavaScript](https://de
 
 `npm start`
 
+[![Run on Repl.it](https://repl.it/badge/github/odoe/jsapi-react)](https://repl.it/github/odoe/jsapi-react)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).